### PR TITLE
Bump version: 1.4.0 → 1.4.1 and add date transformation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cached-prisma",
   "description": "A Prisma client abstraction that simplifies caching.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "repository": "https://github.com/joellefkowitz/cached-prisma",
   "homepage": "https://cached-prisma.readthedocs.io",
   "license": "MIT",

--- a/src/Prisma.ts
+++ b/src/Prisma.ts
@@ -1,5 +1,5 @@
-import { PrismaClient } from "@prisma/client";
 import { LruCache } from "./LruCache";
+import { PrismaClient } from "@prisma/client";
 
 export interface Cache {
   read: (key: string) => Promise<string | null>;

--- a/src/Redis.ts
+++ b/src/Redis.ts
@@ -1,14 +1,28 @@
 import { Cache } from "./Prisma";
-import { Redis as RedisClient } from "ioredis";
+import { Redis as RedisClient, RedisOptions } from "ioredis";
 
 export class Redis implements Cache {
   readonly lifetime: number;
 
   private client: RedisClient;
 
-  constructor(host = "0.0.0.0", port = 6379, lifetime = 10, prefix = "cache") {
-    this.client = new RedisClient(port, host, { keyPrefix: prefix });
-    this.lifetime = lifetime;
+  constructor(
+    hostOrRedisClient: string | RedisClient = "0.0.0.0",
+    portOrOptions: number | RedisOptions = 6379,
+    lifetimeSeconds = 60,
+    prefix = "cache"
+  ) {
+    if (typeof hostOrRedisClient === "string") {
+      if (typeof portOrOptions === "number") {
+        this.client = new RedisClient(portOrOptions, hostOrRedisClient, { keyPrefix: prefix });
+      } else {
+        this.client = new RedisClient(hostOrRedisClient, portOrOptions);
+      }
+    } else {
+      this.client = hostOrRedisClient;
+    }
+
+    this.lifetime = lifetimeSeconds;
   }
 
   read(key: string): Promise<string | null> {


### PR DESCRIPTION
# Pull Request

## Description
If having DateTime type on some of the properties, while caching that date will turn into a string, and such will be returned on next fetch, resulting in any methods such as `.getTime()` on that property throwing errors. This fixes that.

## Current Behavior
Dates are converted into string in cache and such returned.
```prisma
model Test {
  id String @id @default(uuid())

  date DateTime @default(now())
}
```
```ts
// After its cached:
await prisma.test.findMany()
// -> { id: string; date: string; }[]
```

## New Behavior
Fields that match date from JSON will be date.
```prisma
model Test {
  id String @id @default(uuid())

  date DateTime @default(now())
}
```
```ts
// After its cached:
await prisma.test.findMany()
// -> { id: string; date: Date; }[]
